### PR TITLE
feat: 完善文章状态的定义，在文章失效时根据失效原因记录不同状态

### DIFF
--- a/article_checker/article_checker.py
+++ b/article_checker/article_checker.py
@@ -11,8 +11,9 @@ from docx.shared import Cm, Pt, Inches
 from docx.oxml.ns import qn
 from docx.enum.text import WD_PARAGRAPH_ALIGNMENT
 from queue import Queue
+from update_reason import *
 
-def default_callback(article_id, valid, backup_path):
+def default_callback(article_id, valid, backup_path=None, optionals={}):
     return
 
 def IsValidUrl(url):
@@ -102,13 +103,15 @@ class Article_Checker(Thread):
     def DoArticleDeleted(self, article_id, url, delete_reason):
         print('article id {} deleted for {}'.format(article_id, delete_reason))
         # to do
-        self.call_back_func(article_id=article_id, valid=False, backup_path=None)
+        self.call_back_func(article_id=article_id, valid=False, 
+                            backup_path=None, optionals={"reason":REASON_INACCESSIBLE})
         return
 
     def DoArticleDeletedWithoutDownload(self, article_id, url, delete_reason):
         # to do
         print('article id {} deleted for {}'.format(article_id, delete_reason))
-        self.call_back_func(article_id=article_id, valid=False, backup_path=None)
+        self.call_back_func(article_id=article_id, valid=False, 
+                            backup_path=None, optionals={"reason":REASON_INACCESSIBLE})
         return
 
     def DoConnectionError(self, url):
@@ -119,7 +122,8 @@ class Article_Checker(Thread):
     def DoInvalidUrl(self, article_id, url):
         # to do
         print('Invalid Url : {}'.format(url))
-        self.call_back_func(article_id=article_id, valid=False, backup_path=None)
+        self.call_back_func(article_id=article_id, valid=False, 
+                            backup_path=None, optionals={"reason":REASON_INVALID_URL})
         return
 
     def DoRequestError(self, url):

--- a/article_checker/update_reason.py
+++ b/article_checker/update_reason.py
@@ -1,0 +1,7 @@
+
+
+REASON_DELETE_BY_USER = "delete_by_user"
+REASON_INACCESSIBLE   = "inaccessible"
+REASON_OUT_OF_DATE    = "out_of_date"
+REASON_INVALID_URL    = "invalid_url"
+REASON_NULL           = "null"

--- a/database/db_operator.py
+++ b/database/db_operator.py
@@ -209,7 +209,7 @@ class DbOperator:
         """
         insert_new_article = (
             "INSERT INTO articles (URL, open_id, backup_addr, start_date, status) "
-            "VALUES (%s, %s, %s, NOW(), 0);")  # status 0 表示初次添加，状态未知
+            "VALUES (%s, %s, %s, NOW(), %s);")
         return self._commit_cmd(insert_new_article, article)
 
     def find_article(self, article_id):
@@ -340,7 +340,7 @@ class DbOperator:
         article_id = article['article_id']
         self.remove_article(article_id)
         new_record = (article_id, article['URL'], article['open_id'],
-                    article['backup_addr'], article['start_date'])
+                    article['backup_addr'], article['start_date'], article['status'])
         return self._add_archive(new_record)
 
     def _add_archive(self, article):
@@ -356,10 +356,10 @@ class DbOperator:
         """
         insert_new_article = (
             "INSERT INTO archive (article_id, URL, open_id, backup_addr, start_date, end_date, status) "
-            "VALUES (%s, %s, %s, %s, %s, NOW(), 8);")  # status 8 用来表示存档的文件
+            "VALUES (%s, %s, %s, %s, %s, NOW(), %s);")
         return self._commit_cmd(insert_new_article, article)
 
-    def db_add_helper(self, URL, open_id, backup_addr):
+    def db_add_helper(self, URL, open_id, backup_addr, status):
         """This function if for special purpose when adding info to database.
         It returns article_id if adding successed.
 
@@ -374,7 +374,7 @@ class DbOperator:
             success: bool
             article_id: int
         """
-        article = (URL, open_id, backup_addr)
+        article = (URL, open_id, backup_addr, status)
         if not self.add_article(article):  # 执行add操作
             logger.warning("add_article fail, with paras:"
                         + " ".join(map(str, article)))

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,20 @@
+from article_checker.update_reason import *
+
+# article status definition：
+#  watching status
+STATUS_NEW_UNKNOWN = 0 # 初次添加，状态未知
+STATUS_NORMAL_OB = 1 # 正常访问，正常观察状态
+STATUS_NOT_VALID = 2 # 不可访问
+STATUS_BAD_REQUEST = 3 # 网络异常，初次添加后直接访问失败
+#  archive status
+STATUS_INACCESSIBLE = 7 # 观察期内链接失效的存档状态
+STATUS_OUT_OF_DATE = 8 # 观察超过30天的存档状态
+STATUS_DELETE_BY_USER = 9 # 用户主动删除的存档状态
+
+reason2status = {
+    REASON_DELETE_BY_USER : STATUS_DELETE_BY_USER,
+    REASON_INACCESSIBLE   : STATUS_INACCESSIBLE,
+    REASON_OUT_OF_DATE    : STATUS_OUT_OF_DATE,
+    REASON_INVALID_URL    : STATUS_NOT_VALID,
+    REASON_NULL           : STATUS_NORMAL_OB
+}

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import logging
 from database.db_operator import DbOperator
 from observer import Observer, update_article_status
 from my_timer import RepeatedTimer
+from definitions import *
 
 #先声明一个 Logger 对象
 logger = logging.getLogger("main")
@@ -199,7 +200,7 @@ class MainLogic(object):
             return "试图删除编号为" + str(article_id) + "的文章，但未找到"
         user = msg.source
         if result['open_id'] == user: # 确实是本人的观察目标
-            if update_article_status(article_id, False):
+            if update_article_status(article_id, False, optionals={"reason": REASON_DELETE_BY_USER}):
                 return "成功删除观察目标：" + str(article_id)
             else:
                 logger.error("_delete process fail: " + string)


### PR DESCRIPTION
修改了 update_article_status 接口，新增一个可选参数 optionals，可以在其中填写状态变更原因
observer 根据原因区分记录状态，从而可以在事后得知为何停止观察

close #49
BREAKING CHANGE: 当文章停止观察时必须填写原因，否则会触发状态更新异常