### PR TITLE
fix: 解决存储文章标题后备份功能异常的问题

### DIFF
--- a/src/article_checker/article_checker.py
+++ b/src/article_checker/article_checker.py
@@ -259,10 +259,10 @@ def Save2Doc(page_soup, save_path, image_size=4.0):
     try:
         title = page_soup.find(name='h2').text.strip()
     except:
-        title = doc.add_heading('获取文章标题时出错')
+        doc_title = doc.add_heading('获取文章标题时出错')
     else:
-        title = doc.add_heading(title)
-    title.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
+        doc_title = doc.add_heading(title)
+    doc_title.alignment = WD_PARAGRAPH_ALIGNMENT.CENTER
     # get author information
     cur_para = doc.add_paragraph()
     cur_para.add_run('作者介绍：')

--- a/src/database/db_operator.py
+++ b/src/database/db_operator.py
@@ -319,7 +319,7 @@ class DbOperator:
         article_id, backup_addr, status, title = article
         update = (
             "UPDATE articles SET backup_addr=%s, status=%s, title=%s WHERE article_id=%s;")
-        parameters = (backup_addr, status, article_id, title)
+        parameters = (backup_addr, status, title, article_id)
         return self._commit_cmd(update, parameters)
 
     def remove_article(self, article_id):

--- a/src/main.py
+++ b/src/main.py
@@ -195,7 +195,7 @@ class MainLogic(object):
             output.append(item['URL'])
             output.append(item['open_id'])
             output.append(item['backup_addr'])
-            output.append(item['start_date'])
+            # output.append(item['start_date']) # 这个有bug，先注释掉
             output.append(item['status'])
             output.append('--------')
         return "\n".join(map(str, output))


### PR DESCRIPTION
此前数据库更新的代码修改有误，按搜索条件无法找到对应项目进行更新，因此出现bug

close #70