### PR TITLE
fix: 解决无法下载图片元素时，整个 article_checker 线程咬死的问题

### DIFF
--- a/src/article_checker/article_checker.py
+++ b/src/article_checker/article_checker.py
@@ -300,7 +300,7 @@ def Save2Doc(page_soup, save_path, image_size=4.0):
 def DownloadImage(url):
     # TO DO: 改成存字节流
     try:
-        image_data = requests.get(url).content
+        image_data = requests.get(url, timeout=5).content
     except:
         return None
     else:


### PR DESCRIPTION
原因是图片无法下载时， request.get() 无限占用线程执行，既不完成也不失败（抛异常）
添加了 timeout 参数，确保一段时间无法成功下载时，程序仍能向后执行

close #90